### PR TITLE
Pequenas correções em mtcarros e pinguins

### DIFF
--- a/inst/specs/mtcars.yml
+++ b/inst/specs/mtcars.yml
@@ -3,8 +3,8 @@ df:
   name: mtcarros
 variables:
   mpg:
-    trans: milhares
-    desc: Milhares por galão (EUA)
+    trans: milhas_por_galao
+    desc: "Milhas por galão (US)"
   cyl:
     trans: cilindros
     desc: "Número de cilindros"
@@ -19,7 +19,7 @@ variables:
     desc: "Relação de eixo traseiro"
   wt:
     trans: peso
-    desc: Peso (1000 libra)
+    desc: Peso (1000 libras)
   qsec:
     trans: velocidade
     desc: Tempo em percorrer 1/4 de milha

--- a/inst/specs/penguins.yml
+++ b/inst/specs/penguins.yml
@@ -3,7 +3,7 @@ df:
   name: pinguins
 variables:
   species:
-    trans: especies
+    trans: especie
     desc: Um fator com as espécies de pinguim (Pinguim-de-adélia, Pinguim-de-barbicha e Pinguim-gentoo)
     values:
       Adelie: "Pinguim-de-adélia"

--- a/man/mtcarros.rd
+++ b/man/mtcarros.rd
@@ -4,12 +4,12 @@
 \title{Testes de estrada para automóveis}
 \format{Um data.frame com 32 linhas e 12 colunas
 \describe{
-\item{milhares}{Milhares por galão (EUA)}
+\item{milhas_por_galao}{Milhas por galão (US)}
 \item{cilindros}{Número de cilindros}
 \item{cilindrada}{Volume de deslocamento do motor em polegadas cúbicas}
 \item{cavalos_forca}{Cavalos força bruto}
 \item{eixo}{Relação de eixo traseiro}
-\item{peso}{Peso (1000 libra)}
+\item{peso}{Peso (1000 libras)}
 \item{velocidade}{Tempo em percorrer 1/4 de milha}
 \item{forma}{Forma do motor (V ou em linha)}
 \item{transmissao}{Tipo de transmissão (0 = automático, 1 = manual)}

--- a/man/pinguins.rd
+++ b/man/pinguins.rd
@@ -4,7 +4,7 @@
 \title{Medidas de pinguins adultos perto da Estação Palmer, Antártida (Palmer Station)}
 \format{Um tibble com 344 linhas e 8 colunas
 \describe{
-\item{especies}{Um fator com as espécies de pinguim (Pinguim-de-adélia, Pinguim-de-barbicha e Pinguim-gentoo)}
+\item{especie}{Um fator com as espécies de pinguim (Pinguim-de-adélia, Pinguim-de-barbicha e Pinguim-gentoo)}
 \item{ilha}{Um fator com cada ilha do Arquipélago Palmer, na Antártida (Biscoe, Dream, Togersen)}
 \item{comprimento_bico}{Um número inteiro que indica o comprimento do bico (em milímetros)}
 \item{profundidade_bico}{Um número inteiro que indica a profundidade do bico (em milímetros)}


### PR DESCRIPTION


Em pinguins, a coluna estava como `especies`, porém o adequado seria `especie`.

Em mtcarros, a coluna mpg estava como `milhares`, alterado para `milhas_por_galao`
