### PR TITLE
Pixar_films

### DIFF
--- a/inst/specs/pixar_films.yml
+++ b/inst/specs/pixar_films.yml
@@ -47,7 +47,7 @@ variables:
     values:
       G: Livre
       PG: "Orientação parental sugerida"
-      N/A: N/A
+      N/A: NA
       Not Rated: "Não avaliado"
 help:
   name: pixar_filmes

--- a/inst/specs/pixar_films.yml
+++ b/inst/specs/pixar_films.yml
@@ -38,6 +38,17 @@ variables:
   release_date:
     trans: data_lancamento
     desc: "Data de lançamento do filme"
+  run_time:
+    trans: duracao
+    desc: "Duração do filme em minutos"
+  film_rating:
+    trans: classificacao_indicativa
+    desc: "Classificação indicativa baseada no sistema de classificação de filmes da Motion Picture Association (MPA)"
+    values:
+      G: Livre
+      PG: "Orientação parental sugerida"
+      N/A: N/A
+      Not Rated: "Não avaliado"
 help:
   name: pixar_filmes
   alias: pixar_filmes


### PR DESCRIPTION
- tradução de duas novas variaveis: run_time e film_rating


- film_rating é o que precisamos ter mais atenção. Essa é a referência: https://en.wikipedia.org/wiki/Motion_Picture_Association_film_rating_system

Os valores únicos:
```
> unique(pixarfilms::pixar_films$film_rating)
[1] "G"         "PG"        "N/A"      
[4] "Not Rated"
```

Como traduzi:

```
    values:
      G: Livre
      PG: "Orientação parental sugerida"
      N/A: N/A
      Not Rated: "Não avaliado"
```

obs: perguntei ao autor do pacote se o N/A é igual ao `NA`.