### PR TITLE
Column tailnum: Fixing flights and planes

### DIFF
--- a/inst/specs/flights.yml
+++ b/inst/specs/flights.yml
@@ -36,7 +36,7 @@ variables:
     trans: voo
     desc: "N\u00famero do voo"
   tailnum:
-    trans: numero_cauda
+    trans: codigo_cauda
     desc: "N\u00famero da cauda do avi\u00e3o"
   origin:
     trans: origem

--- a/inst/specs/flights.yml
+++ b/inst/specs/flights.yml
@@ -36,7 +36,7 @@ variables:
     trans: voo
     desc: "N\u00famero do voo"
   tailnum:
-    trans: cauda
+    trans: numero_cauda
     desc: "N\u00famero da cauda do avi\u00e3o"
   origin:
     trans: origem

--- a/inst/specs/flights.yml
+++ b/inst/specs/flights.yml
@@ -37,7 +37,7 @@ variables:
     desc: "N\u00famero do voo"
   tailnum:
     trans: codigo_cauda
-    desc: "N\u00famero da cauda do avi\u00e3o"
+    desc: "C\u00f3digo da cauda do avi\u00e3o (empenagem)"
   origin:
     trans: origem
     desc: "Origem do voo. Ver `aeroportos` para metadados adicionais"

--- a/inst/specs/planes.yml
+++ b/inst/specs/planes.yml
@@ -3,8 +3,8 @@ df:
   name: avioes
 variables:
   tailnum:
-    trans: codigo_cauda
-    desc: "C\u00f3digo da cauda do avi\u00e3o (empenagem)"
+    trans: numero_cauda
+    desc: "N\u00famero da cauda do avi\u00e3o (empenagem)"
   year:
     trans: ano
     desc: "Ano de fabrica\u00e7\u00e3o"

--- a/inst/specs/planes.yml
+++ b/inst/specs/planes.yml
@@ -4,7 +4,7 @@ df:
 variables:
   tailnum:
     trans: numero_cauda
-    desc: "N\u00famero da cauda do avi\u00e3o (empenagem)"
+    desc: "C\u00f3digo da cauda do avi\u00e3o (empenagem)"
   year:
     trans: ano
     desc: "Ano de fabrica\u00e7\u00e3o"

--- a/inst/specs/planes.yml
+++ b/inst/specs/planes.yml
@@ -3,7 +3,7 @@ df:
   name: avioes
 variables:
   tailnum:
-    trans: numero_cauda
+    trans: codigo_cauda
     desc: "C\u00f3digo da cauda do avi\u00e3o (empenagem)"
   year:
     trans: ano


### PR DESCRIPTION
While translating, @scopinho noticed that the datasets `planes` and `flights` are used to show join operations, using the `tailnum` column as a key.

But when we translated, we didn't notice that was the same column, and in each dataset this column has different name: cauda and numero_cauda.

So this PR changes the name of the two columns to "codigo_cauda".